### PR TITLE
Your order - background photo

### DIFF
--- a/src/css/order.css
+++ b/src/css/order.css
@@ -4,6 +4,7 @@
   margin-bottom: 80px;
   background-repeat: no-repeat;
   background-position: center;
+  background-position-y: top;
   background-size: cover;
   background-image: url(../img/order/photo-bgr/photo-mobile@1x.png);
 }

--- a/src/partials/order.html
+++ b/src/partials/order.html
@@ -57,10 +57,10 @@
         <img
           class="order-img"
           srcset="
-            ./img/order/order-desktop@1x.jpg  320w,
-            ./img/order/order-desktop@2x.jpg  640w,
-            ./img/order/order-tablet@1x.jpg   638w,
-            ./img/order/order-tablet@2x.jpg  1276w
+            ../img/order/order-desktop@1x.jpg  320w,
+            ../img/order/order-desktop@2x.jpg  640w,
+            ../img/order/order-tablet@1x.jpg   638w,
+            ../img/order/order-tablet@2x.jpg  1276w
           "
           sizes="(min-width:1280px) 524px, (min-width:768px) 638px"
           src="../img/order/order-desktop@1x.jpg"


### PR DESCRIPTION
бекграунд фото дівчинки обрізаеться через те що фото не розраховане на таке розтягування сильне і сайт його намагаеться розтянути як треба на width 100% і воно зжирає його
коли ставлю ліміт на ширину то ця фотка приліпає до лівої сторони чогось..
тому можу запропонувати це рішення коли сайт буде розтягуючи фото брати максимальний у і тому фото буде обрізатися у нижній частині

також подивіться будь ласка секцію about us там контейнер цієї секції вілізає за усі рамки і тому у всього сайта з правої сторони великий відступ
це починаеться з 1280px, на 1350 зникає і потім на 1440 знову з'являється і на 1500 зникає